### PR TITLE
chore: combine duplicate selectors

### DIFF
--- a/templates/sandbox-react-index-css.txt
+++ b/templates/sandbox-react-index-css.txt
@@ -14,6 +14,11 @@ body {
 
 body {
   padding: 2rem;
+  
+  /* From: https://github.com/carbon-design-system/carbon/blob/v10.22.0/packages/type/scss/_reset.scss#L31-L32 */
+  font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
 }
 
 /* Minimum setting to use IBM Plex font */
@@ -33,11 +38,4 @@ body {
   src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
     url(https://fonts.gstatic.com/s/ibmplexsans/v6/zYX9KVElMYYaJe8bpLHnCwDKjQ76AIFscg.woff) format('woff');
   font-display: auto;
-}
-
-/* From: https://github.com/carbon-design-system/carbon/blob/v10.22.0/packages/type/scss/_reset.scss#L31-L32 */
-body {
-  font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
 }


### PR DESCRIPTION
This PR combines the `body` style rules in 1 block 

originally the duplicate selectors caused a stylelint warning

![image](https://user-images.githubusercontent.com/8265238/129921607-519b7e5f-5b79-4ab3-960d-3690dd9e4f23.png)
